### PR TITLE
Add func get_clients for mes api and update Examples.md

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -1,4 +1,4 @@
-<p align="center">
+P<p align="center">
     <a href="https://github.com/OctoDiary">
         <img src="https://avatars.githubusercontent.com/u/90847608?s=200&v=4" alt="OctoDiary" width="200">
     </a>
@@ -559,14 +559,15 @@ async def mobile_api():
     api.token = await sms_code.async_enter_code(code)
 
     # получаем ID профиля
-    profile_id = (await api.get_users_profiles_info())[0].id
+    profile_id = (await api.get_users_profile_info())[0].id
 
     # Получаем инфо о профиле и сохраняем некоторые важные данные, которые будут нужны
     profile = await api.get_family_profile(profile_id=profile_id)
     mes_role = profile.profile.type                      # тип пользователя
     person_id = profile.children[0].contingent_guid      # person-id ученика
     student_id = profile.children[0].id                  # <STUDENT-ID>
-    contract_id = profile.children[0].contract_id        # <CONTRACT-ID>
+    clients = await api.get_clients(person_id=person_id)
+    contract_id = clients.client_id.contract_id          # <CONTRACT-ID>
 
     # получить сохраненные настройки приложения пользователя (тема и т.д.)
     settings = await api.get_user_settings_app(profile_id=profile_id)
@@ -712,7 +713,7 @@ def mobile_api():
     API методы и запросы, которые делает приложение "Дневник МЭШ" для получения данных
     """
 
-    api = AsyncMobileAPI(system=Systems.MES)
+    api = SyncMobileAPI(system=Systems.MES)
 
     # авторизовываемся, получаем токен и сохраняем его
     login = input("Логин: ")
@@ -730,7 +731,8 @@ def mobile_api():
     mes_role = profile.profile.type                      # тип пользователя
     person_id = profile.children[0].contingent_guid      # person-id ученика
     student_id = profile.children[0].id                  # <STUDENT-ID>
-    contract_id = profile.children[0].contract_id        # <CONTRACT-ID>
+    clients = api.get_clients(person_id=person_id)
+    contract_id = clients.client_id.contract_id          # <CONTRACT-ID>
 
     # получить сохраненные настройки приложения пользователя (тема и т.д.)
     settings = api.get_user_settings_app(profile_id=profile_id)

--- a/octodiary/apis/async_.py
+++ b/octodiary/apis/async_.py
@@ -45,6 +45,8 @@ from octodiary.types.mobile import (
     UserSettings,
     UsersProfilesInfo,
     Visits,
+    Homeworks,
+    DoneHomework,
 )
 from octodiary.types.mobile.subject_marks import SubjectsMarks
 from octodiary.types.model import Type
@@ -613,6 +615,62 @@ class AsyncMobileAPI(AsyncBaseAPI):
                 "profile-id": profile_id,
             },
             model=ShortHomeworks,
+        )
+        
+    async def get_homeworks(
+            self,
+            student_id: int,
+            profile_id: int,
+            from_date: Optional[date] = None,
+            to_date: Optional[date] = None,
+    ) -> Homeworks:
+        """
+        Retrieves a list of short homeworks for a given student within a specified date range.
+
+        Args:
+            student_id (int): The ID of the student.
+            profile_id (int): The ID of the profile.
+            from_date (date): The start date of the range.
+            to_date (date): The end date of the range.
+            sort_column (str, optional): The column to sort the homeworks by. Defaults to "date".
+            sort_direction (str, optional): The direction to sort the homeworks in. Defaults to "asc".
+
+        Returns:
+            ShortHomeworks: The short homeworks object.
+        """
+        return await self.request(
+            method="GET",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path="/family/mobile/v1/homeworks",
+            params={
+                "student_id": student_id,
+                "from": self.date_to_string(from_date),
+                "to": self.date_to_string(to_date)
+            },
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+                "client-type": "diary-mobile",
+                "profile-id": profile_id,
+            },
+            model=Homeworks,
+        )
+        
+    async def done_homework(
+            self,
+            profile_id: int,
+            homework_entry_id: int,
+            done: bool,
+    ):
+        return await self.request(
+            method="POST" if done else "DELETE",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path=f"/family/mobile/v1/homeworks/{homework_entry_id}/done",
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+                "client-type": "diary-mobile",
+                "profile-id": profile_id,
+            },
+            model=DoneHomework,
         )
 
     async def get_marks(

--- a/octodiary/apis/async_.py
+++ b/octodiary/apis/async_.py
@@ -21,6 +21,7 @@ from octodiary.types.captcha import async_generate_captcha_class
 from octodiary.types.enter_sms_code import EnterSmsCode
 from octodiary.types.mobile import (
     ClassMembers,
+    Clients,
     DayBalanceInfo,
     EventsResponse,
     FamilyProfile,
@@ -508,6 +509,29 @@ class AsyncMobileAPI(AsyncBaseAPI):
             },
             json=settings.model_dump(),
             return_raw_text=True
+        )
+        
+    async def get_clients(self, person_id: int) -> Clients:
+        """
+        Get clients
+
+        Args:
+            person_id (str): The ID of the person.
+
+        Returns:
+            FamilyProfile: The family profile of the person.
+        """
+        return await self.request(
+            method="GET",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path="/meals/v2/clients",
+            params={
+                "personId": person_id
+            },
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+            },
+            model=Clients
         )
 
     async def get_events(

--- a/octodiary/apis/sync.py
+++ b/octodiary/apis/sync.py
@@ -46,6 +46,8 @@ from octodiary.types.mobile import (
     UserSettings,
     UsersProfilesInfo,
     Visits,
+    Homeworks,
+    DoneHomework,
 )
 from octodiary.types.mobile.subject_marks import SubjectsMarks
 from octodiary.types.model import Type
@@ -606,6 +608,62 @@ class SyncMobileAPI(SyncBaseAPI):
                 "profile-id": profile_id,
             },
             model=ShortHomeworks,
+        )
+        
+    def get_homeworks(
+            self,
+            student_id: int,
+            profile_id: int,
+            from_date: Optional[date] = None,
+            to_date: Optional[date] = None,
+    ) -> Homeworks:
+        """
+        Retrieves a list of short homeworks for a given student within a specified date range.
+
+        Args:
+            student_id (int): The ID of the student.
+            profile_id (int): The ID of the profile.
+            from_date (date): The start date of the range.
+            to_date (date): The end date of the range.
+            sort_column (str, optional): The column to sort the homeworks by. Defaults to "date".
+            sort_direction (str, optional): The direction to sort the homeworks in. Defaults to "asc".
+
+        Returns:
+            ShortHomeworks: The short homeworks object.
+        """
+        return self.request(
+            method="GET",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path="/family/mobile/v1/homeworks",
+            params={
+                "student_id": student_id,
+                "from": self.date_to_string(from_date),
+                "to": self.date_to_string(to_date)
+            },
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+                "client-type": "diary-mobile",
+                "profile-id": profile_id,
+            },
+            model=Homeworks,
+        )
+        
+    def done_homework(
+            self,
+            profile_id: int,
+            homework_entry_id: int,
+            done: bool,
+    ):
+        return self.request(
+            method="POST" if done else "DELETE",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path=f"/family/mobile/v1/homeworks/{homework_entry_id}/done",
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+                "client-type": "diary-mobile",
+                "profile-id": profile_id,
+            },
+            model=DoneHomework,
         )
 
     def get_marks(

--- a/octodiary/apis/sync.py
+++ b/octodiary/apis/sync.py
@@ -22,6 +22,7 @@ from octodiary.types.captcha import generate_captcha_class
 from octodiary.types.enter_sms_code import EnterSmsCode
 from octodiary.types.mobile import (
     ClassMembers,
+    Clients,
     DayBalanceInfo,
     EventsResponse,
     FamilyProfile,
@@ -501,6 +502,29 @@ class SyncMobileAPI(SyncBaseAPI):
             },
             json=settings.model_dump(),
             return_raw_text=True
+        )
+        
+    def get_clients(self, person_id: int) -> Clients:
+        """
+        Get clients
+
+        Args:
+            person_id (str): The ID of the person.
+
+        Returns:
+            FamilyProfile: The family profile of the person.
+        """
+        return self.request(
+            method="GET",
+            base_url=BaseURL(type=URLTypes.SCHOOL_API, system=self.system),
+            path="/meals/v2/clients",
+            params={
+                "personId": person_id
+            },
+            custom_headers={
+                "x-mes-subsystem": "familymp",
+            },
+            model=Clients
         )
 
     def get_events(

--- a/octodiary/types/mobile/__init__.py
+++ b/octodiary/types/mobile/__init__.py
@@ -27,6 +27,8 @@ from octodiary.types.mobile.user_childrens import UserChildrens
 from octodiary.types.mobile.user_settings import UserSettings
 from octodiary.types.mobile.users_profiles_info import UsersProfilesInfo
 from octodiary.types.mobile.visits import Visits
+from octodiary.types.mobile.homeworks import Homeworks
+from octodiary.types.mobile.homeworks import DoneHomework
 
 __all__ = [
     "ClassMembers",
@@ -55,4 +57,6 @@ __all__ = [
     "UserChildrens",
     "UsersProfilesInfo",
     "Visits",
+    "Homeworks",
+    "DoneHomework",
 ]

--- a/octodiary/types/mobile/__init__.py
+++ b/octodiary/types/mobile/__init__.py
@@ -4,6 +4,7 @@
 #           https://github.com/OctoDiary
 
 from octodiary.types.mobile.class_members import ClassMembers
+from octodiary.types.mobile.clients import Clients
 from octodiary.types.mobile.day_balance_info import DayBalanceInfo
 from octodiary.types.mobile.events import EventsResponse
 from octodiary.types.mobile.family_profile import FamilyProfile
@@ -29,6 +30,7 @@ from octodiary.types.mobile.visits import Visits
 
 __all__ = [
     "ClassMembers",
+    "Clients",
     "DayBalanceInfo",
     "EventsResponse",
     "FamilyProfile",

--- a/octodiary/types/mobile/clients.py
+++ b/octodiary/types/mobile/clients.py
@@ -1,0 +1,42 @@
+#                 © Copyright 2023
+#          Licensed under the MIT License
+#        https://opensource.org/licenses/MIT
+#           https://github.com/OctoDiary
+
+from typing import Any, Optional
+
+from pydantic import Field
+
+from octodiary.types.model import DT, Type
+
+
+class ClientId(Type):
+    contract_id: int = Field(alias="contractId")
+    staff_id: Optional[int] = Field(..., alias="staffId")
+    person_id: Optional[str] = Field(..., alias="personId")
+
+
+class Organization(Type):
+    name: Optional[str] = None
+    type: Optional[str] = None
+    address: Optional[str] = None
+
+
+class ExpenseConstraints(Type):
+    balance_threshold: Optional[int] = Field(..., alias="balanceThreshold")
+    expense_day_limit: Optional[int] = Field(..., alias="expenseDayLimit")
+
+
+class Clients(Type):
+    client_id: ClientId = Field(alias="clientId")
+    organization: Organization
+    preorder_allowed: Optional[bool] = Field(..., alias="preorderAllowed")
+    balance: Optional[int] = None
+    foodbox_allowed: Optional[bool] = Field(..., alias="foodboxAllowed")
+    foodbox_available: Optional[bool] = Field(..., alias="foodboxAvailable")
+    preorder_available: Optional[bool] = Field(..., alias="preorderAvailable")
+    expense_constraints: ExpenseConstraints = Field(alias="expenseConstraints")
+    rnipsc: Optional[str] = None
+
+    class Config:
+        populate_by_name = True

--- a/octodiary/types/mobile/homeworks.py
+++ b/octodiary/types/mobile/homeworks.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+from octodiary.types.model import DT, Type
+
+
+from typing import Optional, List
+from datetime import datetime as DT
+from pydantic import BaseModel
+
+
+class Material(BaseModel):
+    uuid: Optional[str] = None
+    type: Optional[str] = None
+    selected_mode: Optional[str] = None
+    type_name: Optional[str] = None
+    id: Optional[int] = None
+    urls: Optional[List[str]] = None
+    description: Optional[str] = None
+    content_type: Optional[str] = None
+    title: Optional[str] = None
+    action_id: Optional[int] = None
+    action_name: Optional[str] = None
+
+
+class Payload(BaseModel):
+    type: Optional[str] = None
+    description: Optional[str] = None
+    comments: Optional[List[str]] = None
+    materials: Optional[List[Material]] = None
+    homework: Optional[str] = None
+    homework_entry_student_id: Optional[int] = None
+    attachments: Optional[List[str]] = None
+    subject_id: Optional[int] = None
+    group_id: Optional[int] = None
+    date: Optional[DT] = None
+    date_assigned_on: Optional[str] = None
+    subject_name: Optional[str] = None
+    lesson_date_time: Optional[DT] = None
+    is_done: Optional[bool] = None
+    has_teacher_answer: Optional[bool] = None
+    homework_id: Optional[int] = None
+    homework_entry_id: Optional[int] = None
+    homework_created_at: Optional[DT] = None
+    homework_updated_at: Optional[DT] = None
+    written_answer: Optional[str] = None
+    date_prepared_for: Optional[DT] = None
+
+
+class Homeworks(Type):
+    payload: list[Payload] | None = None
+
+
+class DoneHomework(Type):
+    success: bool = None


### PR DESCRIPTION
### Добавлена функция `get_clients` для `MobileAPI` и исправлены примеры в `Examples.md`

- Только для МЭШ API
- Позволяет получить contract_id, который требуется для получения посещаемости (`/family/mobile/v1/visits`)
- Позволяет получить баланс пользователя (альтернатива `/family/mobile/v1/status`)

#### Запрос:
```
GET https://school.mos.ru/api/meals/v2/clients
Headers: { X-mes-subsystem: familymp }
Params: { personId: <person_id> }
```

#### Ответ:
```json
{
    "clientId": {
        "contractId": "<contractId>",
        "staffId": null,
        "personId": "<personId>"
    },
    "organization": {
        "name": "<name>",
        "type": "<type>",
        "address": "<address>"
    },
    "preorderAllowed": false,
    "balance": "<balance>",
    "foodboxAllowed": false,
    "foodboxAvailable": false,
    "preorderAvailable": true,
    "expenseConstraints": {
        "balanceThreshold": null,
        "expenseDayLimit": 0
    },
    "rnipsc": "<rnipsc>"
}
```

